### PR TITLE
El Capitan does not let you access /usr/bin anymore

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 rm /usr/bin/amigomake 2>/dev/null
-ln -s $(pwd)/src/amigomake /usr/bin/amigomake
+ln -s $(pwd)/src/amigomake /usr/local/bin/amigomake

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-rm /usr/bin/amigomake 2>/dev/null
+rm /usr/local/bin/amigomake 2>/dev/null
 ln -s $(pwd)/src/amigomake /usr/local/bin/amigomake


### PR DESCRIPTION
The wonderful folks at Apple decided that we are not worthy to modify `/usr/bin` anymore even in sudo... `/usr/local/bin` is fine, however...

http://apple.stackexchange.com/questions/193368/what-is-the-rootless-feature-in-el-capitan-really
